### PR TITLE
Implement admin section with Firestore integration

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import ExamWizard from './pages/ExamWizard';
 import ReportView from './pages/ReportView';
+import AdminPanel from './pages/AdminPanel';
 import './styles/index.css';
 
 function App() {
@@ -14,6 +15,7 @@ function App() {
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/exam" element={<ExamWizard />} />
         <Route path="/reports" element={<ReportView />} />
+        <Route path="/admin" element={<AdminPanel />} />
       </Routes>
     </Router>
   );

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,11 @@
 import { initializeApp } from 'firebase/app';
-import { getAuth, GoogleAuthProvider, signInWithPopup, signOut } from 'firebase/auth';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signOut,
+} from 'firebase/auth';
+import { getFirestore, doc, getDoc } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,6 +19,7 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const provider = new GoogleAuthProvider();
+export const db = getFirestore(app);
 
 export async function signInWithGoogle() {
   await signInWithPopup(auth, provider);
@@ -20,4 +27,9 @@ export async function signInWithGoogle() {
 
 export async function signOutUser() {
   await signOut(auth);
+}
+
+export async function getAdminConfig() {
+  const snap = await getDoc(doc(db, 'roles', 'admin'));
+  return snap.exists() ? (snap.data() as { email: string; route: string }) : null;
 }

--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthState } from 'react-firebase-hooks/auth';
+import { auth, db, getAdminConfig } from '../firebase';
+import { doc, setDoc } from 'firebase/firestore';
+
+export default function AdminPanel() {
+  const [user] = useAuthState(auth);
+  const [adminEmail, setAdminEmail] = useState<string | null>(null);
+  const [className, setClassName] = useState('');
+  const [selectedClass, setSelectedClass] = useState('');
+  const [subjectName, setSubjectName] = useState('');
+  const [file, setFile] = useState<File | null>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getAdminConfig().then((cfg) => setAdminEmail(cfg?.email ?? null));
+  }, []);
+
+  if (!user) return null;
+  if (adminEmail && user.email !== adminEmail) {
+    return <div className="p-4">Unauthorized</div>;
+  }
+
+  const handleAddClass = async () => {
+    if (!className) return;
+    await setDoc(doc(db, 'classes', className), { name: className });
+    setSelectedClass(className);
+    setClassName('');
+  };
+
+  const handleAddSubject = async () => {
+    if (!selectedClass || !subjectName) return;
+    await setDoc(doc(db, 'classes', selectedClass, 'subjects', subjectName), {
+      name: subjectName,
+    });
+    setSubjectName('');
+  };
+
+  const handleUpload = async () => {
+    if (!file || !selectedClass || !subjectName) return;
+    const text = await file.text();
+    const questions = JSON.parse(text);
+    await setDoc(doc(db, 'classes', selectedClass, 'subjects', subjectName), {
+      name: subjectName,
+      questions,
+    });
+    setFile(null);
+    alert('Question bank uploaded');
+  };
+
+  return (
+    <div className="p-4 space-y-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold">Admin Panel</h1>
+
+      <div>
+        <input
+          className="border p-2 mr-2"
+          type="text"
+          placeholder="Class (e.g. 5)"
+          value={className}
+          onChange={(e) => setClassName(e.target.value)}
+        />
+        <button
+          onClick={handleAddClass}
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Add Class
+        </button>
+      </div>
+
+      <div>
+        <input
+          className="border p-2 mr-2"
+          type="text"
+          placeholder="Class"
+          value={selectedClass}
+          onChange={(e) => setSelectedClass(e.target.value)}
+        />
+        <input
+          className="border p-2 mr-2"
+          type="text"
+          placeholder="Subject"
+          value={subjectName}
+          onChange={(e) => setSubjectName(e.target.value)}
+        />
+        <button
+          onClick={handleAddSubject}
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Add Subject
+        </button>
+      </div>
+
+      <div>
+        <input
+          type="file"
+          accept="application/json"
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+          className="mb-2"
+        />
+        <button
+          onClick={handleUpload}
+          className="bg-green-500 text-white px-4 py-2 rounded"
+        >
+          Upload Question Bank
+        </button>
+      </div>
+
+      <button onClick={() => navigate('/dashboard')} className="underline">
+        Back to Dashboard
+      </button>
+    </div>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,21 @@
 import { useNavigate } from 'react-router-dom';
-import { signOutUser } from '../firebase';
+import { signOutUser, getAdminConfig } from '../firebase';
 import { auth } from '../firebase';
 import { useAuthState } from 'react-firebase-hooks/auth';
+import { useEffect, useState } from 'react';
 
 export default function Dashboard() {
   const navigate = useNavigate();
   const [user] = useAuthState(auth);
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    async function check() {
+      const cfg = await getAdminConfig();
+      if (cfg && user?.email === cfg.email) setIsAdmin(true);
+    }
+    check();
+  }, [user]);
 
   if (!user) return null;
 
@@ -30,6 +40,14 @@ export default function Dashboard() {
       >
         View Past Reports
       </button>
+      {isAdmin && (
+        <button
+          className="block w-full bg-purple-500 text-white py-2 rounded"
+          onClick={() => navigate('/admin')}
+        >
+          Admin Panel
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Firestore initialization and helper to get admin info
- expose admin panel page for uploading question banks
- show admin button on dashboard when user email matches roles/admin
- route `/admin` to the new page

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854b92e92a08321987105bf496d0aaa