### PR TITLE
Add exam cancel option and result details

### DIFF
--- a/src/pages/ExamWizard.tsx
+++ b/src/pages/ExamWizard.tsx
@@ -11,6 +11,12 @@ export default function ExamWizard() {
   const [submitted, setSubmitted] = useState(false);
   const navigate = useNavigate();
 
+  const cancel = () => {
+    if (confirm('Cancel the exam? Your progress will be lost.')) {
+      navigate('/dashboard');
+    }
+  };
+
   const total = 10;
   const examQs = questions.slice(0, total);
   const currentQ = examQs[current];
@@ -45,8 +51,40 @@ export default function ExamWizard() {
     const score = examQs.reduce((acc, q, idx) =>
       answers[idx] === q.answer ? acc + 1 : acc, 0);
     return (
-      <div className="p-4 space-y-4 max-w-xl mx-auto">
+      <div className="p-4 space-y-4 max-w-3xl mx-auto">
         <h2 className="text-xl font-bold">Your Score: {score} / {total}</h2>
+        <div className="overflow-x-auto">
+          <table className="table-auto w-full border">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="border px-2 py-1">#</th>
+                <th className="border px-2 py-1">Question</th>
+                <th className="border px-2 py-1">Options</th>
+                <th className="border px-2 py-1">Your Answer</th>
+                <th className="border px-2 py-1">Correct</th>
+                <th className="border px-2 py-1">Explanation</th>
+              </tr>
+            </thead>
+            <tbody>
+              {examQs.map((q, idx) => (
+                <tr key={q.id} className="align-top">
+                  <td className="border px-2 py-1 text-center">{idx + 1}</td>
+                  <td className="border px-2 py-1">{q.question}</td>
+                  <td className="border px-2 py-1">
+                    <ul className="list-disc ml-4">
+                      {q.options.map(opt => (
+                        <li key={opt} className={opt === q.answer ? 'font-semibold' : ''}>{opt}</li>
+                      ))}
+                    </ul>
+                  </td>
+                  <td className="border px-2 py-1">{answers[idx] || 'Skipped'}</td>
+                  <td className="border px-2 py-1">{q.answer}</td>
+                  <td className="border px-2 py-1">{q.explanation}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
         <button
           className="bg-blue-500 text-white px-4 py-2 rounded"
           onClick={() => navigate('/dashboard')}
@@ -59,7 +97,10 @@ export default function ExamWizard() {
 
   return (
     <div className="p-4 max-w-xl mx-auto">
-      <div className="mb-4">Question {current + 1} / {total}</div>
+      <div className="flex justify-between mb-4">
+        <span>Question {current + 1} / {total}</span>
+        <button onClick={cancel} className="text-sm underline">Cancel</button>
+      </div>
       <QuestionCard question={currentQ} selected={answers[current]} onSelect={handleSelect} />
       <div className="flex justify-between mt-4">
         <button onClick={prev} disabled={current === 0} className="px-4 py-2 bg-gray-300 rounded">Previous</button>


### PR DESCRIPTION
## Summary
- allow cancelling the exam mid-way
- display detailed answers table after submission

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854c20af1708321af518dc8c61a5f4c