### PR TITLE
Improve question upload validation

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -17,8 +17,9 @@ export default function Toast({ message, show, onClose }: ToastProps) {
   if (!show) return null;
 
   return (
-    <div className="fixed top-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow">
-      {message}
+    <div className="fixed top-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow flex items-start">
+      <span className="flex-1">{message}</span>
+      <button onClick={onClose} className="ml-2 text-white">&#10005;</button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance `Toast` component with a close button
- provide detailed validation errors in `validateQuestion`
- surface validation errors when uploading, adding or modifying questions

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685696ae12248321bd5c55bc96b4c51a