### PR TITLE
Fallback to local questions when Firestore empty

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
## Summary
- add fallback questions to `ExamWizard`
- support Vite env types in `tsconfig.json`

## Testing
- `npm run build`
- `npx tsc --noEmit` *(fails: Argument of type 'Question' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6856a67d7520832190e54db319dc084d