### PR TITLE
Add answer highlights to results

### DIFF
--- a/src/pages/ExamWizard.tsx
+++ b/src/pages/ExamWizard.tsx
@@ -148,12 +148,21 @@ export default function ExamWizard() {
                   <td className="border px-2 py-1">
                     <ul className="list-disc ml-4">
                       {q.options.map(opt => (
-                        <li key={opt} className={opt === q.answer ? 'font-semibold' : ''}>{opt}</li>
+                        <li
+                          key={opt}
+                          className={opt === q.answer ? 'font-semibold bg-green-100' : ''}
+                        >
+                          {opt}
+                        </li>
                       ))}
                     </ul>
                   </td>
-                  <td className="border px-2 py-1">{answers[idx] || 'Skipped'}</td>
-                  <td className="border px-2 py-1">{q.answer}</td>
+                  <td
+                    className={`border px-2 py-1 ${answers[idx] === q.answer ? 'bg-green-100' : 'bg-red-100'}`}
+                  >
+                    {answers[idx] || 'Skipped'}
+                  </td>
+                  <td className="border px-2 py-1 bg-green-100">{q.answer}</td>
                   <td className="border px-2 py-1">{q.explanation}</td>
                 </tr>
               ))}

--- a/src/pages/ReportView.tsx
+++ b/src/pages/ReportView.tsx
@@ -23,9 +23,17 @@ export default function ReportView() {
                 <li key={idx} className="mb-1">
                   <span className="font-semibold">Q:</span> {d.question}
                   <br />
-                  <span className="font-semibold">Your Answer:</span> {d.selected || 'Skipped'}
+                  <span className="font-semibold">Your Answer:</span>{' '}
+                  <span
+                    className={
+                      d.selected === d.correct ? 'bg-green-100 px-1' : 'bg-red-100 px-1'
+                    }
+                  >
+                    {d.selected || 'Skipped'}
+                  </span>
                   <br />
-                  <span className="font-semibold">Correct:</span> {d.correct}
+                  <span className="font-semibold">Correct:</span>{' '}
+                  <span className="bg-green-100 px-1">{d.correct}</span>
                   <br />
                   <span className="italic text-sm">{d.explanation}</span>
                 </li>


### PR DESCRIPTION
## Summary
- highlight the correct option and the correct answer in the result table
- color the user's answer based on correctness
- apply the same highlighting to report view

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856a8adb0b48321a63038f87d6bbb05