### PR TITLE
Add question filtering based on past performance

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,10 +1,18 @@
 // Utilities for saving and loading exam reports using localStorage
+export interface ExamDetail {
+  id: string | number;
+  question: string;
+  selected: string | undefined;
+  correct: string;
+  explanation: string;
+}
+
 export interface ExamReport {
   id: string;
   timestamp: number;
   score: number;
   total: number;
-  details: any;
+  details: ExamDetail[];
 }
 
 const STORAGE_KEY = 'exam_reports';


### PR DESCRIPTION
## Summary
- track question ids when saving reports
- filter exam questions based on previous mistakes or unseen questions

## Testing
- `npm install`
- `npx -y vite build`

------
https://chatgpt.com/codex/tasks/task_e_6856aaa11d508321945cb792f9aae01b