### PR TITLE
Improve exam question randomness and admin list features

### DIFF
--- a/src/pages/AdminPanel.tsx
+++ b/src/pages/AdminPanel.tsx
@@ -46,6 +46,9 @@ export default function AdminPanel() {
 
   const [newItem, setNewItem] = useState('');
   const [toast, setToast] = useState('');
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
 
   const navigate = useNavigate();
 
@@ -88,6 +91,7 @@ export default function AdminPanel() {
       )
     );
     setQuestions(snap.docs.map(d => ({ id: d.id, ...(d.data() as Question) })));
+    setPage(1);
   }
 
   const addItem = async () => {
@@ -338,6 +342,15 @@ export default function AdminPanel() {
     return <div className="p-4">Unauthorized</div>;
   }
 
+  const filteredQuestions = questions.filter(q =>
+    q.question.toLowerCase().includes(search.toLowerCase())
+  );
+  const totalPages = Math.ceil(filteredQuestions.length / pageSize) || 1;
+  const paginated = filteredQuestions.slice(
+    (page - 1) * pageSize,
+    page * pageSize
+  );
+
   return (
     <div className="p-4 space-y-4 max-w-2xl mx-auto">
       <h1 className="text-2xl font-bold">Admin Panel</h1>
@@ -429,13 +442,26 @@ export default function AdminPanel() {
       )}
       {view === 'questions' && (
         <div className="space-y-2">
+          <div className="flex justify-between items-center">
+            <span>Total Questions: {filteredQuestions.length}</span>
+            <input
+              type="text"
+              className="border p-1 rounded"
+              placeholder="Search"
+              value={search}
+              onChange={e => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+            />
+          </div>
           <button
             onClick={addQuestion}
             className="bg-blue-500 text-white px-4 py-2 rounded"
           >
             Add Question
           </button>
-          {questions.map(q => (
+          {paginated.map(q => (
             <div key={q.id} className="border p-2 flex justify-between items-start">
               <span>{q.question}</span>
               <div className="space-x-2 text-sm">
@@ -444,6 +470,23 @@ export default function AdminPanel() {
               </div>
             </div>
           ))}
+          <div className="flex justify-between items-center">
+            <button
+              disabled={page === 1}
+              className="px-2 py-1 border rounded"
+              onClick={() => setPage(p => Math.max(1, p - 1))}
+            >
+              Prev
+            </button>
+            <span>Page {page} / {totalPages}</span>
+            <button
+              disabled={page === totalPages}
+              className="px-2 py-1 border rounded"
+              onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+            >
+              Next
+            </button>
+          </div>
         </div>
       )}
       <button onClick={() => navigate("/dashboard")} className="underline">

--- a/src/pages/ExamWizard.tsx
+++ b/src/pages/ExamWizard.tsx
@@ -15,6 +15,13 @@ export default function ExamWizard() {
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
 
+  const shuffle = (arr: any[]) => {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+  };
+
   const cancel = () => {
     if (confirm('Cancel the exam? Your progress will be lost.')) {
       navigate('/dashboard');
@@ -75,8 +82,7 @@ export default function ExamWizard() {
           });
         }
         data = data.filter(q => failed.has(q.id) || !attempted.has(q.id));
-        const order = ['Easy', 'Medium', 'Hard', 'Over-achiever'];
-        data.sort((a, b) => order.indexOf(a.difficulty_level) - order.indexOf(b.difficulty_level));
+        shuffle(data);
         setExamQs(data.slice(0, 10));
       } catch (e) {
         console.error('Failed to load questions from Firestore, using fallback.', e);
@@ -104,8 +110,7 @@ export default function ExamWizard() {
           });
         }
         data = data.filter(q => failed.has(q.id) || !attempted.has(q.id));
-        const order = ['Easy', 'Medium', 'Hard', 'Over-achiever'];
-        data.sort((a, b) => order.indexOf(a.difficulty_level) - order.indexOf(b.difficulty_level));
+        shuffle(data);
         setExamQs(data.slice(0, 10));
       } finally {
         setLoading(false);


### PR DESCRIPTION
## Summary
- randomize question selection in ExamWizard so each exam is more dynamic
- show total questions in AdminPanel, add search, and paginate list

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856af5fc420832188def5a1ae9f2c3a