### PR TITLE
Enable report filters

### DIFF
--- a/src/pages/ExamWizard.tsx
+++ b/src/pages/ExamWizard.tsx
@@ -169,6 +169,7 @@ export default function ExamWizard() {
     const report = {
       id: uuid(),
       timestamp: Date.now(),
+      subject,
       score,
       total,
       details: examQs.map((q, idx) => ({

--- a/src/pages/ReportView.tsx
+++ b/src/pages/ReportView.tsx
@@ -5,17 +5,85 @@ import { useNavigate } from 'react-router-dom';
 export default function ReportView() {
   const navigate = useNavigate();
   const [reports] = useState(loadReports());
+  const [subjectFilter, setSubjectFilter] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [page, setPage] = useState(0);
+
+  const subjects = Array.from(new Set(reports.map(r => r.subject)));
+  const PAGE_SIZE = 5;
+
+  let filtered = reports;
+  if (subjectFilter) {
+    filtered = filtered.filter(r => r.subject === subjectFilter);
+  }
+  if (startDate) {
+    const ts = new Date(startDate).getTime();
+    filtered = filtered.filter(r => r.timestamp >= ts);
+  }
+  if (endDate) {
+    const ts = new Date(endDate).getTime() + 86400000 - 1;
+    filtered = filtered.filter(r => r.timestamp <= ts);
+  }
+
+  const pages = Math.ceil(filtered.length / PAGE_SIZE);
+  const paginated = filtered.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE);
 
   return (
     <div className="p-4 max-w-xl mx-auto space-y-4">
       <h1 className="text-2xl font-bold">Past Reports</h1>
-      {reports.length === 0 && <p>No reports yet.</p>}
-      {reports.map(r => (
+
+      <div className="space-y-2 border p-2 rounded bg-gray-50">
+        <div>
+          <label className="block mb-1">Subject</label>
+          <select
+            className="border p-1 rounded w-full"
+            value={subjectFilter}
+            onChange={e => {
+              setSubjectFilter(e.target.value);
+              setPage(0);
+            }}
+          >
+            <option value="">All</option>
+            {subjects.map(s => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block mb-1">Attempted After</label>
+          <input
+            type="date"
+            className="border p-1 rounded w-full"
+            value={startDate}
+            onChange={e => {
+              setStartDate(e.target.value);
+              setPage(0);
+            }}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Attempted Before</label>
+          <input
+            type="date"
+            className="border p-1 rounded w-full"
+            value={endDate}
+            onChange={e => {
+              setEndDate(e.target.value);
+              setPage(0);
+            }}
+          />
+        </div>
+      </div>
+
+      {paginated.length === 0 && <p>No reports found.</p>}
+      {paginated.map(r => (
         <div key={r.id} className="border p-2 rounded">
           <div className="flex justify-between">
             <span>{new Date(r.timestamp).toLocaleString()}</span>
             <span>{r.score} / {r.total}</span>
           </div>
+          <div className="text-sm mb-1">Subject: {r.subject}</div>
           <details className="mt-2">
             <summary className="cursor-pointer">Details</summary>
             <ul className="list-disc ml-4">
@@ -42,6 +110,29 @@ export default function ReportView() {
           </details>
         </div>
       ))}
+
+      {pages > 1 && (
+        <div className="flex justify-between">
+          <button
+            className="px-2 py-1 rounded bg-gray-300"
+            disabled={page === 0}
+            onClick={() => setPage(p => Math.max(p - 1, 0))}
+          >
+            Previous
+          </button>
+          <span className="self-center">
+            Page {page + 1} / {pages}
+          </span>
+          <button
+            className="px-2 py-1 rounded bg-gray-300"
+            disabled={page >= pages - 1}
+            onClick={() => setPage(p => Math.min(p + 1, pages - 1))}
+          >
+            Next
+          </button>
+        </div>
+      )}
+
       <button
         className="bg-blue-500 text-white py-2 px-4 rounded"
         onClick={() => navigate('/dashboard')}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -10,6 +10,8 @@ export interface ExamDetail {
 export interface ExamReport {
   id: string;
   timestamp: number;
+  /** Subject for which the exam was attempted */
+  subject: string;
   score: number;
   total: number;
   details: ExamDetail[];
@@ -25,5 +27,10 @@ export function saveReport(report: ExamReport) {
 
 export function loadReports(): ExamReport[] {
   const raw = localStorage.getItem(STORAGE_KEY);
-  return raw ? (JSON.parse(raw) as ExamReport[]) : [];
+  if (!raw) return [];
+  const parsed: any[] = JSON.parse(raw);
+  return parsed.map(r => ({
+    subject: r.subject || 'unknown',
+    ...r
+  })) as ExamReport[];
 }


### PR DESCRIPTION
## Summary
- track exam subject in saved reports
- filter reports by subject and date
- paginate report list

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856c236d0108321afccc957c6b679da